### PR TITLE
Add generic info to run `pnpm` apps on Windows

### DIFF
--- a/PNPM_ON_WINDOWS.md
+++ b/PNPM_ON_WINDOWS.md
@@ -1,0 +1,7 @@
+# Running Commerce Layer Apps with pnpm on Windows
+
+When working on Microsoft Windows, we suggest to use the PowerShell terminal or any alternative shell with the ability to run scripts as admin user.
+
+This is required to install `pnpm` following the instruction [here](https://pnpm.io/installation#on-windows).
+
+Once done, install globally the `touch-cli` package by running `pnpm add -g touch-cli` in order to successfully execute the `prepare` script (where provided).


### PR DESCRIPTION
This generic file can be linked across all our apps.
In this way we won't risk to dups things or use not updated content.