### PR TITLE
Close issue instead of referring to it

### DIFF
--- a/.github/workflows/dependencies-update-pnpm.yaml
+++ b/.github/workflows/dependencies-update-pnpm.yaml
@@ -373,7 +373,7 @@ jobs:
         shell: bash
         run: |
           cat > /tmp/pnpm-pr-header.md <<EOF
-          **Related to ${{ steps.issue.outputs.url }}**
+          **Closes ${{ steps.issue.outputs.url }}**
           **Branch:** \`${{ steps.branch.outputs.name }}\`
           **Based on stable:** \`${{ steps.tag.outputs.stable }}\`
           **Prerelease tag:** \`${{ inputs.use_tags && steps.tag.outputs.name || 'skipped' }}\`


### PR DESCRIPTION
## What I did

This PR makes a small update to the dependencies update workflow. The change updates the pull request header to use "Closes" instead of "Related to" when referencing the associated issue URL, clarifying the intent that the PR will close the linked issue.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
