### PR TITLE
Limit semver updates to the last day in dependencies update workflow

### DIFF
--- a/.github/workflows/dependencies-update-pnpm.yaml
+++ b/.github/workflows/dependencies-update-pnpm.yaml
@@ -146,7 +146,7 @@ jobs:
         id: semver
         uses: commercelayer/.github/.github/actions/collect-ncu-report@main
         with:
-          command: pnpm dlx npm-check-updates --packageFile '**/package.json' -u -t semver
+          command: pnpm dlx npm-check-updates --packageFile '**/package.json' -u -t semver -c 1d
           empty_message: No semver updates found.
           output_file: /tmp/pnpm-semver.log
 


### PR DESCRIPTION
Added `-c 1d` flag to `ncu` to respect minimum release age